### PR TITLE
Fixed a bug in custom action manager where it fails if you don't specify scriptsrc

### DIFF
--- a/Sherpa.Library/SiteHierarchy/CustomActionsManager.cs
+++ b/Sherpa.Library/SiteHierarchy/CustomActionsManager.cs
@@ -11,6 +11,23 @@ namespace Sherpa.Library.SiteHierarchy
     {
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
+        private string CreateUserActioName(ShCustomAction customAction)
+        {
+            if (!string.IsNullOrEmpty(customAction.Id))
+            {
+                return customAction.Id;
+            }
+            else if (!String.IsNullOrEmpty(customAction.ScriptSrc))
+            {
+                return customAction.ScriptSrc.Split('/')[customAction.ScriptSrc.Split('/').Length - 1].Replace(".", "");
+            }
+            else if (!String.IsNullOrEmpty(customAction.Sequence.ToString()))
+            {
+                return customAction.Sequence.ToString();
+            }
+            return "";
+        }
+
         public void SetUpCustomActions(ClientContext context, string CustomActionsPrefix, List<ShCustomAction> customActions)
         {
             if (customActions.Count > 0)
@@ -56,10 +73,11 @@ namespace Sherpa.Library.SiteHierarchy
                     userCustomAction.Sequence = customAction.Sequence;
                     userCustomAction.ScriptSrc = customAction.ScriptSrc;
                     userCustomAction.ScriptBlock = customAction.ScriptBlock;
-                    userCustomAction.Name = CustomActionsPrefix + "_" + customAction.ScriptSrc.Split('/')[customAction.ScriptSrc.Split('/').Length - 1].Replace(".", "");
+                    userCustomAction.Name = String.Format("{0}_{1}", CustomActionsPrefix, CreateUserActioName(customAction));
                     userCustomAction.Description = customAction.Description;
                     userCustomAction.RegistrationType = customAction.RegistrationType;
                     userCustomAction.Title = customAction.Title;
+                    userCustomAction.Url = customAction.Url;
                     userCustomAction.ImageUrl = customAction.ImageUrl;
                     userCustomAction.Group = customAction.Group;
 

--- a/Sherpa.Library/SiteHierarchy/Model/ShCustomAction.cs
+++ b/Sherpa.Library/SiteHierarchy/Model/ShCustomAction.cs
@@ -4,6 +4,7 @@ namespace Sherpa.Library.SiteHierarchy.Model
 {
     public class ShCustomAction
     {
+        public string Id { get; set; }
         public string Description { get; set; }
         public string Group { get; set; }
         public string ImageUrl { get; set; }


### PR DESCRIPTION
Fixed a bug in custom action manager where it fails if you don't specify
scriptsrc. Because of this fix, all custom action types should now be
supported.